### PR TITLE
fixed crashes on a 32bits target

### DIFF
--- a/pyclassinformer/mc_tree.py
+++ b/pyclassinformer/mc_tree.py
@@ -98,6 +98,8 @@ class mc_tree_t(ida_kernwin.Choose):
             self.dirtree.mkdir(dirtree_path)
             
             bc_path = self.base_class_paths[vftable_ea]
+            if not bc_path:
+                continue
             actual_class_name = bc_path[-1].name
 
             # for vftable folder

--- a/pyclassinformer/method_classifier.py
+++ b/pyclassinformer/method_classifier.py
@@ -32,6 +32,8 @@ def change_dir_of_ctors_dtors(paths, data, dirtree):
     # move virtual functions to its class folder
     for vftable_ea in paths:
         path = paths[vftable_ea]
+        if not path:
+            continue
         
         # get the class name that owns the vftable, which is the last entry of the path.
         class_name = path[-1].name
@@ -62,6 +64,8 @@ def change_dir_of_vfuncs(paths, data, dirtree):
     # move virtual functions to its class folder
     for vftable_ea in paths:
         path = paths[vftable_ea]
+        if not path:
+            continue
         
         # get the class name that owns the vftable, which is the last entry of the path.
         class_name = path[-1].name
@@ -136,6 +140,8 @@ def rename_func(ea, prefix="", fn="", is_lib=False):
 def rename_vftable_ref_funcs(paths, data):
     for vftable_ea in paths:
         path = paths[vftable_ea]
+        if not path:
+            continue
         col = data[vftable_ea]
         
         # get the class name that owns the vftable, which is the last entry of the path.
@@ -163,6 +169,8 @@ def rename_funcs(func_eas, prefix="", is_lib=False):
 def rename_vfuncs(paths, data):
     for vftable_ea in paths:
         path = paths[vftable_ea]
+        if not path:
+            continue
         col = data[vftable_ea]
         
         # get the class name that owns the vftable, which is the last entry of the path.

--- a/pyclassinformer/pci_utils.py
+++ b/pyclassinformer/pci_utils.py
@@ -198,7 +198,8 @@ class utils(object):
         col_offs = utils.get_col_offs(col, vftables)
         
         bases = []
-        for path in col.chd.bca.paths[col.offset]:
+        paths = col.chd.bca.paths.get(col.offset, [])
+        for path in paths:
             append = False
             for bcd in path:
                 # for SI and MI but there is only a vftable


### PR DESCRIPTION
PyClassInformer was prematurely crashing, so now we skip empty entries gracefully.